### PR TITLE
Handle internal server error correctly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,9 @@ group :development do
   gem 'rake', '~> 12.0'
   gem 'rspec', '~> 3.0'
 
-  gem 'rubocop', '~> 1.57'
-  gem 'rubocop-performance', '~> 1.19.0'
-  gem 'rubocop-rspec', '~> 2.25.0'
+  gem 'rubocop', '~> 1.75.5'
+  gem 'rubocop-performance', '~> 1.25.0'
+  gem 'rubocop-rspec', '~> 3.6.0'
 
   gem 'timecop', '~> 0.9.8'
 

--- a/lib/pay_pro/api_client.rb
+++ b/lib/pay_pro/api_client.rb
@@ -71,12 +71,7 @@ module PayPro
 
       case pay_pro_response.status
       when 401
-        raise AuthenticationError.new(
-          message: 'Invalid API key supplied. ' \
-                   'Make sure to set a correct API key without any whitespace around it. ' \
-                   'You can find your API key in the PayPro dashboard at "https://app.paypro.nl/developers/api-keys".',
-          **default_params
-        )
+        raise authentication_error(**default_params)
       when 404
         raise ResourceNotFoundError.new(message: 'Resource not found', **default_params)
       when 422
@@ -86,11 +81,26 @@ module PayPro
           code: pay_pro_response.data['error']['type'],
           **default_params
         )
+      when 500
+        raise PayPro::Error.new(
+          message: pay_pro_response.data['error']['message'],
+          code: pay_pro_response.data['error']['type'],
+          **default_params
+        )
       end
     rescue JSON::ParserError
       raise PayPro::Error.new(
         message: 'Invalid response from API. ' \
                  'The JSON returned in the body is not valid.',
+        **default_params
+      )
+    end
+
+    def authentication_error(**default_params)
+      AuthenticationError.new(
+        message: 'Invalid API key supplied. ' \
+                 'Make sure to set a correct API key without any whitespace around it. ' \
+                 'You can find your API key in the PayPro dashboard at "https://app.paypro.nl/developers/api-keys".',
         **default_params
       )
     end

--- a/spec/pay_pro/api_client_spec.rb
+++ b/spec/pay_pro/api_client_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe PayPro::ApiClient do
       context 'when invalid JSON is returned with a success status' do
         before { stub_request(:get, url).to_return(body: '', status: 200) }
 
-        it 'raises a Error' do
+        it 'raises an Error' do
           expect { request }.to raise_error(
             PayPro::Error,
             'Invalid response from API. The JSON returned in the body is not valid.'
@@ -70,7 +70,7 @@ RSpec.describe PayPro::ApiClient do
       context 'when invalid JSON is returned with a fail status' do
         before { stub_request(:get, url).to_return(body: '', status: 500) }
 
-        it 'raises a Error' do
+        it 'raises an Error' do
           expect { request }.to raise_error(
             PayPro::Error,
             'Invalid response from API. The JSON returned in the body is not valid.'
@@ -120,6 +120,27 @@ RSpec.describe PayPro::ApiClient do
           expect { request }.to raise_error(
             PayPro::ValidationError,
             'Description must be set, with param: "description"'
+          )
+        end
+      end
+
+      context 'with status code 500' do
+        before do
+          stub_request(:get, url).to_return(
+            status: 500,
+            body: {
+              error: {
+                message: 'There was an internal error. Please try again.',
+                type: 'internal_error'
+              }
+            }.to_json
+          )
+        end
+
+        it 'raises an Error' do
+          expect { request }.to raise_error(
+            PayPro::Error,
+            'There was an internal error. Please try again.'
           )
         end
       end


### PR DESCRIPTION
Currently when the server returns a `500 - internal server error` we don't handle it correctly. It should raise a `PayPro::Error` with the message from the response.